### PR TITLE
fixed spelling of installation and choosing

### DIFF
--- a/source/typerio-xyz/app/docs/contributing/choosing-project/page.mdx
+++ b/source/typerio-xyz/app/docs/contributing/choosing-project/page.mdx
@@ -1,4 +1,4 @@
-# Chosing a project
+# Choosing a project
 
 When selecting a project included in Typerio, be guided by keeping in mind that:
 * Typerio is written in pure JavaScript, without high-level abstraction and without using external NPM packages;

--- a/source/typerio-xyz/components/DocsNavbar.tsx
+++ b/source/typerio-xyz/components/DocsNavbar.tsx
@@ -35,7 +35,7 @@ const Navbar = () => {
               href="/docs/typerio-html/installation"
               onClick={handleClick}
             >
-              Instalation
+              Installation
             </Link>
           </li>
           <li>
@@ -90,7 +90,7 @@ const Navbar = () => {
               href="/docs/typerio-react/installation"
               onClick={handleClick}
             >
-              Instalation
+              Installation
             </Link>
           </li>
           <li>
@@ -147,14 +147,14 @@ const Navbar = () => {
           <li>
             <Link
               className={`${styles.link} ${
-                pathname === "/docs/contributing/chosing-project"
+                pathname === "/docs/contributing/choosing-project"
                   ? styles.active
                   : ""
               }`}
-              href="/docs/contributing/chosing-project"
+              href="/docs/contributing/choosing-project"
               onClick={handleClick}
             >
-              Chosing a project
+              Choosing a project
             </Link>
           </li>
           <li>

--- a/source/typerio-xyz/package-lock.json
+++ b/source/typerio-xyz/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typerio-xyz",
-  "version": "0.1.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typerio-xyz",
-      "version": "0.1.0",
+      "version": "2.1.0",
       "dependencies": {
         "@mdx-js/loader": "^3.0.1",
         "@mdx-js/react": "^3.0.1",


### PR DESCRIPTION
In the docs page, Installation and Choosing were spelled wrong, as mentioned in issue #9. This should close #9 

<img width="209" alt="Screenshot 2024-08-08 at 9 40 32 AM" src="https://github.com/user-attachments/assets/e6fc1182-dfbb-46ed-bff9-1541dcdb9542">