### PR TITLE
fix: Remove horizontal scrollbar from docs navbar

### DIFF
--- a/source/typerio-xyz/styles/docsNavbar.module.css
+++ b/source/typerio-xyz/styles/docsNavbar.module.css
@@ -102,7 +102,6 @@
 .navBot {
     position: relative;
 
-    /* width: fit-content; */
     .link {
         display: flex;
         justify-content: center;
@@ -140,9 +139,7 @@
     border: 1px solid var(--grey1);
     border-radius: 6px;
     background-color: #fff;
-
     height: 4vh;
-
     color: var(--grey2);
     font-size: 0.6rem;
 }
@@ -151,19 +148,16 @@
     .navbar {
         position: sticky;
         top: 0;
-
         width: fit-content;
         height: 99vh;
-
         overflow: hidden;
-
         border-right: 2px solid var(--grey1);
     }
 
     .navBot {
         position: absolute;
         bottom: 4px;
-       left: 10px;
+        left: 10px;
         width: 100%;
     }
 

--- a/source/typerio-xyz/styles/docsNavbar.module.css
+++ b/source/typerio-xyz/styles/docsNavbar.module.css
@@ -102,11 +102,10 @@
 .navBot {
     position: relative;
 
-    width: fit-content;
+    /* width: fit-content; */
     .link {
         display: flex;
         justify-content: center;
-
         font-size: 1.2rem;
 
         .p {
@@ -156,16 +155,15 @@
         width: fit-content;
         height: 99vh;
 
-        overflow: auto;
+        overflow: hidden;
 
         border-right: 2px solid var(--grey1);
     }
 
     .navBot {
         position: absolute;
-        bottom: 0;
-        left: 1vw;
-
+        bottom: 4px;
+       left: 10px;
         width: 100%;
     }
 


### PR DESCRIPTION
Fixes Issue #11 
Scrollbar doesn't show up on the docs navbar.
![Screenshot from 2024-08-10 14-22-09](https://github.com/user-attachments/assets/f6a9cfff-63f3-4150-9aa6-709236757e0f)
